### PR TITLE
Workaround for favorita without lineas

### DIFF
--- a/SeviBus/src/main/java/com/sloy/sevibus/ui/adapters/FavoritasAdapter.java
+++ b/SeviBus/src/main/java/com/sloy/sevibus/ui/adapters/FavoritasAdapter.java
@@ -115,11 +115,13 @@ public class FavoritasAdapter extends RecyclerView.Adapter<FavoritasAdapter.Favo
             ((GradientDrawable) background).setColor(favorita.getColor());
 
             StringBuilder sbLineas = new StringBuilder();
-            for (String linea : parada.getNumeroLineas()) {
-                sbLineas.append(linea);
-                sbLineas.append("  ");
+            if (!parada.getNumeroLineas().isEmpty()) {
+                for (String linea : parada.getNumeroLineas()) {
+                    sbLineas.append(linea);
+                    sbLineas.append("  ");
+                }
+                sbLineas.setLength(sbLineas.length() - 2);
             }
-            sbLineas.setLength(sbLineas.length() - 2);
             lineas.setText(sbLineas.toString());
 
             itemView.setOnClickListener(v -> onFavoritaClickListener.onFavoritaClick(favorita));


### PR DESCRIPTION
When a favorite stop has no lines, the code to generate the lines subtitle crashes. It's a stupid bug that would be fixed using a nice join function of Java 8.
This all sucks.

Related https://fabric.io/sloydev/android/apps/com.sloy.sevibus/issues/565c919df5d3a7f76bfbd7c5
