### PR TITLE
Avoids crash when parada asociada is not present

### DIFF
--- a/SeviBus/src/main/java/com/sloy/sevibus/ui/mvp/presenter/FavoritasMainPresenter.java
+++ b/SeviBus/src/main/java/com/sloy/sevibus/ui/mvp/presenter/FavoritasMainPresenter.java
@@ -42,6 +42,8 @@ public class FavoritasMainPresenter implements Presenter<FavoritasMainPresenter.
                   view.hideEmpty();
                   view.showFavoritas(favoritas);
               }
+          }, error -> {
+              view.showError();
           });
     }
 
@@ -58,6 +60,8 @@ public class FavoritasMainPresenter implements Presenter<FavoritasMainPresenter.
         void showFavoritas(List<Favorita> favoritas);
 
         void hideFavoritas();
+
+        void showError();
     }
 
 }

--- a/SeviBus/src/main/java/com/sloy/sevibus/ui/mvp/view/FavoritasMainViewContainer.java
+++ b/SeviBus/src/main/java/com/sloy/sevibus/ui/mvp/view/FavoritasMainViewContainer.java
@@ -1,6 +1,7 @@
 package com.sloy.sevibus.ui.mvp.view;
 
 import android.app.Activity;
+import android.support.design.widget.Snackbar;
 import android.view.View;
 import android.widget.TextView;
 
@@ -101,6 +102,11 @@ public class FavoritasMainViewContainer implements FavoritasMainPresenter.View {
     @Override
     public void hideFavoritas() {
         contenido.setVisibility(View.GONE);
+    }
+
+    @Override
+    public void showError() {
+        Snackbar.make(activity.findViewById(android.R.id.content), R.string.favoritas_main_error, Snackbar.LENGTH_LONG).show();
     }
 
     private void bindViewFavorita(Favorita fav, View v) {

--- a/SeviBus/src/main/java/com/sloy/sevibus/ui/mvp/view/FavoritasMainViewContainer.java
+++ b/SeviBus/src/main/java/com/sloy/sevibus/ui/mvp/view/FavoritasMainViewContainer.java
@@ -104,7 +104,7 @@ public class FavoritasMainViewContainer implements FavoritasMainPresenter.View {
     }
 
     private void bindViewFavorita(Favorita fav, View v) {
-        if (fav != null) {
+        if (fav != null && fav.getParadaAsociada() != null) {
             Integer numero = fav.getParadaAsociada().getNumero();
             TextView text = (TextView) v.findViewById(R.id.favoritas_main_numero);
             View color = v.findViewById(R.id.favoritas_main_color);

--- a/SeviBus/src/main/res/values/strings.xml
+++ b/SeviBus/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
     <string name="paradas_cercanas_cargando">Buscando paradas cercanas a tu posición...</string>
     <string name="lineas_cercanas_cargando">Buscando líneas cercanas a tu posición...</string>
     <string name="lineas_cercanas_empty">No encontramos líneas cercanas a tu posición. ¿Estás fuera de Sevilla?</string>
+    <string name="favoritas_main_error">Ocurrió un error cargando las favoritas :(</string>
     <string name="favoritas_main_empty">Guarda tus paradas favoritas y aparecerán aquí</string>
     <string name="favoritas_main_cargando">Cargando paradas favoritas...</string>
     <string name="search_hint">Nº o nombre</string>

--- a/SeviBus/src/test/java/com/sloy/sevibus/ui/mvp/presenter/FavoritasMainPresenterTest.java
+++ b/SeviBus/src/test/java/com/sloy/sevibus/ui/mvp/presenter/FavoritasMainPresenterTest.java
@@ -87,6 +87,14 @@ public class FavoritasMainPresenterTest {
         verify(view).showFavoritas(favoritas);
     }
 
+    @Test
+    public void shows_error_when_received_an_error() throws Exception {
+        when(obtainFavoritasAction.getFavoritas()).thenReturn(Observable.error(new Exception()));
+
+        presenter.initialize(view);
+
+        verify(view).showError();
+    }
 
     private List<Favorita> favoritasListOf(int count) {
         List<Favorita> res = new ArrayList<>();


### PR DESCRIPTION
Apparently this can happen sometimes. We just handle that case and ignore the bus stop.
Maybe will improve it in the future.

Related: https://fabric.io/sloydev/android/apps/com.sloy.sevibus/issues/571500bbffcdc04250d2ff26
