### PR TITLE
Disable bus location option in map

### DIFF
--- a/SeviBus/src/main/res/layout/fragment_map_options.xml
+++ b/SeviBus/src/main/res/layout/fragment_map_options.xml
@@ -85,6 +85,7 @@
             android:text="Mostrar buses de líneas"
             android:textSize="17sp"
             android:layout_gravity="left|center_vertical"
+            android:visibility="gone"
             android:checked="false"/>
 
         <CheckBox


### PR DESCRIPTION
It hasn't been working for some time. I need to fix it implementing something new.
In the meantime let's remove the option to avoid user frustration.